### PR TITLE
Allow users to override the app_root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,29 @@
-# Ansible HAProxy Role for Debian Wheezy
+# Ansible Monit Role for Debian Wheezy
 
-This role achieves a good level of SSL security as tested by [SSLLabs](http://ssllabs.com/ssltest/).
+This role configures monit to monitor: haproxy, nginx and unicorn.
 
-In your playbook you need the following variables:
+### Optional Configuration
+
+It is assumed your application is located within /home/*username*/*appname*/
+This can be configured with the following variable:
 
 ```yaml
-app_name: my-app
-ssl_certificate: <full SSL chain including key>
-haproxy:
-  backends: "{{ groups['production'] }}"
-```
-
-### Added SSL certificate to Vault
-
-The vault seems to be a good place to securely store your cert. To do this you need to include it using multi-line syntax... this looks like:
-
-```
-ssl_certificate: |
-  -----BEGIN CERTIFICATE-----
-  REST OF CERT...
+  roles:
+    - { role: tholder.monit, app_root: '/var/www/{{ app_name }}'}
 ```
 
 ### Limitations
 
 This role only works with Debian Wheezy for time being.
 
-SSL is forced for all connections.
-
-haproxy.backends specifies a group in your hosts. This entire group becomes your front-ends and looks for resulting server on eth1 on port specified by backend_port. We use rackspace a lot and eth1 is the internal network.
-
 Nginx must be running on port 8080 as the backend.
 
-### Results
+Notifications are sent to "sysops@simpleweb.co.uk"
 
-It's worth checking results with SSL labs, but this should achieve A+ rating with good browser support.
+### Contributing
 
-![SSL Labs Result](https://tomsstuff.s3.amazonaws.com/aplus.png "SSL Labs Result")
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+app_root: /home/{{ ansible_ssh_user }}/{{ app_name }}

--- a/templates/unicorn.monitrc
+++ b/templates/unicorn.monitrc
@@ -1,4 +1,4 @@
-check process unicorn with pidfile /home/{{ ansible_ssh_user }}/{{ app_name }}/shared/tmp/pids/unicorn.pid
+check process unicorn with pidfile {{ app_root }}/shared/tmp/pids/unicorn.pid
   start program "/etc/init.d/unicorn start"
   stop program "/etc/init.d/unicorn stop"
   if 5 restarts within 5 cycles then timeout


### PR DESCRIPTION
Default the path to the original convention over configuration setting
for backward compatibility.

Example of user configuration

``` yaml
roles:
  - { role: tholder.monit, app_root: '/var/www/{{ app_name }}'}
```
